### PR TITLE
著者の登録・更新機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,116 @@
+# Book Management System
+
+Spring Boot + Kotlin + jOOQを使用した書籍管理システム
+
+## 開発環境セットアップ
+
+### 前提条件
+
+このプロジェクトを実行するために必要な環境を以下にまとめています。
+
+#### 必須環境
+- **JDK 21** 
+  - JAVA_HOMEが適切に設定されていること
+
+- **Docker** 
+  - PostgreSQLコンテナを起動するため
+  - Docker Composeも使用します (`compose.yaml`参照)
+
+### データベース準備
+
+このプロジェクトでは、Docker Composeを使用してPostgreSQLコンテナを起動します：
+
+```bash
+# PostgreSQLコンテナを起動
+docker compose up -d postgres
+
+# コンテナの状態確認
+docker compose ps
+
+# ログ確認（必要に応じて）
+docker compose logs postgres
+```
+
+**データベース接続情報**:
+- ホスト: `localhost`
+- ポート: `5432`
+- データベース名: `bookdb`
+- ユーザー名: `postgres`
+- パスワード: `postgres`
+
+```bash
+# PostgreSQLコンテナを停止する場合
+docker compose down
+
+# データも含めて完全に削除する場合
+docker compose down -v
+```
+
+### ビルド & 実行手順
+
+```bash
+# 1. PostgreSQLコンテナ起動
+docker compose up -d postgres
+
+# 2. 依存関係ダウンロード＆jOOQクラス生成
+./gradlew build
+
+# 3. テスト実行
+./gradlew test
+
+# 4. 開発サーバー起動
+./gradlew bootRun
+```
+
+アプリケーションが起動したら、`http://localhost:8080` でアクセスできます。
+
+## プロジェクト構成
+
+### 技術スタック
+- **言語**: Kotlin
+- **フレームワーク**: Spring Boot 3.x
+- **データベース**: PostgreSQL
+- **ORM**: jOOQ
+- **マイグレーション**: Flyway
+- **テスト**: JUnit 5 + Testcontainers
+- **ビルドツール**: Gradle
+
+### ディレクトリ構成
+
+```
+src/
+└── main/kotlin/io/github/t_suguru/book_management/
+    ├── controller/
+    │   ├── AuthorController.kt      // 著者API
+    │   └── BookController.kt        // 書籍API
+    ├── dto/
+    │   ├── AuthorCreateRequest.kt   // 著者作成リクエスト
+    │   ├── AuthorUpdateRequest.kt   // 著者更新リクエスト
+    │   ├── BookCreateRequest.kt     // 書籍作成リクエスト
+    │   └── BookUpdateRequest.kt     // 書籍更新リクエスト
+    ├── domain/
+    │   ├── model/
+    │   │   ├── Author.kt            // 著者ドメインモデル
+    │   │   ├── Book.kt              // 書籍ドメインモデル
+    │   │   └── PublicationStatus.kt // 出版状況enum
+    │   └── repository/
+    │       ├── AuthorRepository.kt  // 著者用リポジトリインターフェース
+    │       └── BookRepository.kt    // 書籍用リポジトリインターフェース
+    ├── infrastructure/
+    │   └── repository/
+    │       ├── AuthorRepositoryImpl.kt  // 著者リポジトリ実装
+    │       └── BookRepositoryImpl.kt    // 書籍リポジトリ実装
+    └── service/
+        ├── AuthorService.kt         // 著者ビジネスロジック
+        └── BookService.kt           // 書籍ビジネスロジック
+```
+
+### 主要なGradleタスク
+```bash
+./gradlew build                  # 全ビルド（テスト含む）
+./gradlew test                   # テスト実行
+./gradlew bootRun               # アプリケーション起動
+./gradlew jooqCodegen           # jOOQクラス生成
+./gradlew flywayMigrate         # DBマイグレーション実行
+./gradlew flywayInfo            # マイグレーション状態確認
+```

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'io.mockk:mockk:1.13.8'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // JOOQコード生成時に使用するPostgreSQLドライバ

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jooq'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'

--- a/src/main/kotlin/io/github/t_suguru/book_management/controller/AuthorController.kt
+++ b/src/main/kotlin/io/github/t_suguru/book_management/controller/AuthorController.kt
@@ -1,0 +1,45 @@
+package io.github.t_suguru.book_management.controller
+
+import io.github.t_suguru.book_management.domain.model.Author
+import io.github.t_suguru.book_management.dto.AuthorCreateRequest
+import io.github.t_suguru.book_management.service.AuthorService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.util.*
+
+/**
+ * 著者API
+ */
+@RestController
+@RequestMapping("/api/authors")
+class AuthorController(
+    private val authorService: AuthorService
+) {
+
+    /**
+     * 著者を作成する
+     */
+    @PostMapping
+    fun createAuthor(@Valid @RequestBody request: AuthorCreateRequest): ResponseEntity<Author> {
+        val author = authorService.createAuthor(request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(author)
+    }
+
+    /**
+     * 著者を更新する
+     */
+    @PutMapping("/{id}")
+    fun updateAuthor(
+        @PathVariable id: UUID,
+        @Valid @RequestBody request: AuthorCreateRequest
+    ): ResponseEntity<Author> {
+        val author = authorService.updateAuthor(id, request)
+        return if (author != null) {
+            ResponseEntity.ok(author)
+        } else {
+            ResponseEntity.notFound().build()
+        }
+    }
+}

--- a/src/main/kotlin/io/github/t_suguru/book_management/domain/model/Author.kt
+++ b/src/main/kotlin/io/github/t_suguru/book_management/domain/model/Author.kt
@@ -1,0 +1,16 @@
+package io.github.t_suguru.book_management.domain.model
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * 著者ドメインモデル
+ */
+data class Author(
+    val id: UUID? = null,
+    val name: String,
+    val birthdate: LocalDate,
+    val createdAt: LocalDateTime? = null,
+    val updatedAt: LocalDateTime? = null
+)

--- a/src/main/kotlin/io/github/t_suguru/book_management/domain/repository/AuthorRepository.kt
+++ b/src/main/kotlin/io/github/t_suguru/book_management/domain/repository/AuthorRepository.kt
@@ -1,0 +1,13 @@
+package io.github.t_suguru.book_management.domain.repository
+
+import io.github.t_suguru.book_management.domain.model.Author
+import java.util.*
+
+/**
+ * 著者用リポジトリインターフェース
+ */
+interface AuthorRepository {
+    fun save(author: Author): Author
+    fun findById(id: UUID): Author?
+    fun update(author: Author): Author
+}

--- a/src/main/kotlin/io/github/t_suguru/book_management/dto/AuthorCreateRequest.kt
+++ b/src/main/kotlin/io/github/t_suguru/book_management/dto/AuthorCreateRequest.kt
@@ -1,0 +1,16 @@
+package io.github.t_suguru.book_management.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Past
+import java.time.LocalDate
+
+/**
+ * 著者作成リクエスト
+ */
+data class AuthorCreateRequest(
+    @field:NotBlank(message = "名前は必須です")
+    val name: String,
+    
+    @field:Past(message = "生年月日は現在の日付より過去である必要があります")
+    val birthdate: LocalDate
+)

--- a/src/main/kotlin/io/github/t_suguru/book_management/infrastructure/repository/AuthorRepositoryImpl.kt
+++ b/src/main/kotlin/io/github/t_suguru/book_management/infrastructure/repository/AuthorRepositoryImpl.kt
@@ -1,0 +1,65 @@
+package io.github.t_suguru.book_management.infrastructure.repository
+
+import io.github.t_suguru.book_management.db.tables.Authors.Companion.AUTHORS
+import io.github.t_suguru.book_management.domain.model.Author
+import io.github.t_suguru.book_management.domain.repository.AuthorRepository
+import org.jooq.DSLContext
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * 著者リポジトリ実装クラス
+ */
+@Repository
+class AuthorRepositoryImpl(
+    private val dsl: DSLContext,
+) : AuthorRepository {
+
+    override fun save(author: Author): Author {
+        val id = UUID.randomUUID()
+        val now = LocalDateTime.now()
+
+        dsl.insertInto(AUTHORS)
+            .set(AUTHORS.ID, id)
+            .set(AUTHORS.NAME, author.name)
+            .set(AUTHORS.BIRTHDATE, author.birthdate)
+            .set(AUTHORS.CREATED_AT, now)
+            .set(AUTHORS.UPDATED_AT, now)
+            .execute()
+
+        return author.copy(
+            id = id,
+            createdAt = now,
+            updatedAt = now
+        )
+    }
+
+    override fun findById(id: UUID): Author? {
+        return dsl.selectFrom(AUTHORS)
+            .where(AUTHORS.ID.eq(id))
+            .fetchOne()
+            ?.let { record ->
+                Author(
+                    id = record.id,
+                    name = record.name!!,
+                    birthdate = record.birthdate!!,
+                    createdAt = record.createdAt,
+                    updatedAt = record.updatedAt
+                )
+            }
+    }
+
+    override fun update(author: Author): Author {
+        val now = LocalDateTime.now()
+
+        dsl.update(AUTHORS)
+            .set(AUTHORS.NAME, author.name)
+            .set(AUTHORS.BIRTHDATE, author.birthdate)
+            .set(AUTHORS.UPDATED_AT, now)
+            .where(AUTHORS.ID.eq(author.id))
+            .execute()
+
+        return author.copy(updatedAt = now)
+    }
+}

--- a/src/main/kotlin/io/github/t_suguru/book_management/service/AuthorService.kt
+++ b/src/main/kotlin/io/github/t_suguru/book_management/service/AuthorService.kt
@@ -1,0 +1,48 @@
+package io.github.t_suguru.book_management.service
+
+import io.github.t_suguru.book_management.domain.model.Author
+import io.github.t_suguru.book_management.domain.repository.AuthorRepository
+import io.github.t_suguru.book_management.dto.AuthorCreateRequest
+import org.springframework.stereotype.Service
+import java.util.*
+
+/**
+ * 著者ビジネスロジック
+ */
+@Service
+class AuthorService(
+    private val authorRepository: AuthorRepository
+) {
+
+    /**
+     * 著者を作成する
+     */
+    fun createAuthor(request: AuthorCreateRequest): Author {
+        val author = Author(
+            name = request.name,
+            birthdate = request.birthdate
+        )
+        return authorRepository.save(author)
+    }
+
+    /**
+     * 著者を更新する
+     */
+    fun updateAuthor(id: UUID, request: AuthorCreateRequest): Author? {
+        val existingAuthor = authorRepository.findById(id) ?: return null
+        
+        val updatedAuthor = existingAuthor.copy(
+            name = request.name,
+            birthdate = request.birthdate
+        )
+        
+        return authorRepository.update(updatedAuthor)
+    }
+
+    /**
+     * IDで著者を取得する
+     */
+    fun getAuthorById(id: UUID): Author? {
+        return authorRepository.findById(id)
+    }
+}

--- a/src/main/kotlin/io/github/t_suguru/book_management/service/AuthorService.kt
+++ b/src/main/kotlin/io/github/t_suguru/book_management/service/AuthorService.kt
@@ -4,6 +4,7 @@ import io.github.t_suguru.book_management.domain.model.Author
 import io.github.t_suguru.book_management.domain.repository.AuthorRepository
 import io.github.t_suguru.book_management.dto.AuthorCreateRequest
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 /**
@@ -17,6 +18,7 @@ class AuthorService(
     /**
      * 著者を作成する
      */
+    @Transactional
     fun createAuthor(request: AuthorCreateRequest): Author {
         val author = Author(
             name = request.name,
@@ -28,6 +30,7 @@ class AuthorService(
     /**
      * 著者を更新する
      */
+    @Transactional
     fun updateAuthor(id: UUID, request: AuthorCreateRequest): Author? {
         val existingAuthor = authorRepository.findById(id) ?: return null
         

--- a/src/test/kotlin/io/github/t_suguru/book_management/controller/AuthorControllerTest.kt
+++ b/src/test/kotlin/io/github/t_suguru/book_management/controller/AuthorControllerTest.kt
@@ -1,0 +1,292 @@
+package io.github.t_suguru.book_management.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.t_suguru.book_management.AbstractIntegrationTest
+import io.github.t_suguru.book_management.dto.AuthorCreateRequest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.util.*
+
+/**
+ * 著者APIの統合テスト
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional // 各テスト後にロールバックしてデータベース状態を元に戻す
+class AuthorControllerTest : AbstractIntegrationTest() {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Nested
+    inner class CreateAuthorTests {
+
+        @Test
+        fun `正常な著者データで著者を作成できること`() {
+            // Given
+            val request = AuthorCreateRequest(
+                name = "夏目漱石",
+                birthdate = LocalDate.of(1867, 2, 9)
+            )
+
+            // When & Then
+            mockMvc.perform(
+                post("/api/authors")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.name").value("夏目漱石"))
+                .andExpect(jsonPath("$.birthdate").value("1867-02-09"))
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.id").isString)
+                .andExpect(jsonPath("$.createdAt").exists())
+                .andExpect(jsonPath("$.updatedAt").exists())
+        }
+
+        @Test
+        fun `空の名前でバリデーションエラーが発生すること`() {
+            // Given
+            val request = AuthorCreateRequest(
+                name = "",
+                birthdate = LocalDate.of(1867, 2, 9)
+            )
+
+            // When & Then
+            mockMvc.perform(
+                post("/api/authors")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `空白のみの名前でバリデーションエラーが発生すること`() {
+            // Given
+            val request = AuthorCreateRequest(
+                name = "   ",
+                birthdate = LocalDate.of(1867, 2, 9)
+            )
+
+            // When & Then
+            mockMvc.perform(
+                post("/api/authors")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `未来の生年月日でバリデーションエラーが発生すること`() {
+            // Given
+            val request = AuthorCreateRequest(
+                name = "未来人",
+                birthdate = LocalDate.now().plusDays(1)
+            )
+
+            // When & Then
+            mockMvc.perform(
+                post("/api/authors")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `今日の日付の生年月日でバリデーションエラーが発生すること`() {
+            // Given
+            val request = AuthorCreateRequest(
+                name = "今日生まれ",
+                birthdate = LocalDate.now()
+            )
+
+            // When & Then
+            mockMvc.perform(
+                post("/api/authors")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `複数のバリデーションエラーが同時に発生すること`() {
+            // Given
+            val request = AuthorCreateRequest(
+                name = "", // 空の名前 → NotBlankエラー
+                birthdate = LocalDate.now().plusDays(1) // 未来の日付 → Pastエラー
+            )
+
+            // When & Then
+            val result = mockMvc.perform(
+                post("/api/authors")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isBadRequest)
+                .andReturn()
+
+            // デバッグ用: 実際のレスポンス内容を出力
+            println("Response Status: ${result.response.status}")
+            println("Response Body: ${result.response.contentAsString}")
+        }
+
+        @Test
+        fun `不正な日付フォーマットでエラーが発生すること`() {
+            // Given
+            val invalidDateJson = """{"name": "夏目漱石", "birthdate": "invalid-date"}"""
+
+            // When & Then
+            mockMvc.perform(
+                post("/api/authors")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidDateJson)
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `Content-Typeが指定されていない場合エラーが発生すること`() {
+            // Given
+            val request = AuthorCreateRequest(
+                name = "夏目漱石",
+                birthdate = LocalDate.of(1867, 2, 9)
+            )
+
+            // When & Then
+            mockMvc.perform(
+                post("/api/authors")
+                    .content(objectMapper.writeValueAsString(request))
+            )
+                .andExpect(status().isUnsupportedMediaType)
+        }
+    }
+
+    @Nested
+    inner class UpdateAuthorTests {
+
+        @Test
+        fun `存在する著者を正常に更新できること`() {
+            // Given
+            val createRequest = AuthorCreateRequest(
+                name = "夏目漱石",
+                birthdate = LocalDate.of(1867, 2, 9)
+            )
+
+            val createResult = mockMvc.perform(
+                post("/api/authors")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest))
+            )
+                .andExpect(status().isCreated)
+                .andReturn()
+
+            val createResponse = createResult.response.contentAsString
+            val createdAuthor = objectMapper.readTree(createResponse)
+            val authorId = createdAuthor.get("id").asText()
+
+            val updateRequest = AuthorCreateRequest(
+                name = "夏目漱石（ペンネーム）",
+                birthdate = LocalDate.of(1867, 2, 9)
+            )
+
+            // When & Then
+            mockMvc.perform(
+                put("/api/authors/$authorId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(updateRequest))
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.id").value(authorId))
+                .andExpect(jsonPath("$.name").value("夏目漱石（ペンネーム）"))
+                .andExpect(jsonPath("$.birthdate").value("1867-02-09"))
+                .andExpect(jsonPath("$.createdAt").exists())
+                .andExpect(jsonPath("$.updatedAt").exists())
+        }
+
+        @Test
+        fun `存在しない著者IDで404エラーが発生すること`() {
+            // Given
+            val nonExistentId = UUID.randomUUID()
+            val updateRequest = AuthorCreateRequest(
+                name = "存在しない著者",
+                birthdate = LocalDate.of(1867, 2, 9)
+            )
+
+            // When & Then
+            mockMvc.perform(
+                put("/api/authors/$nonExistentId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(updateRequest))
+            )
+                .andExpect(status().isNotFound)
+        }
+
+        @Test
+        fun `無効なUUID形式で400エラーが発生すること`() {
+            // Given
+            val invalidId = "invalid-uuid"
+            val updateRequest = AuthorCreateRequest(
+                name = "夏目漱石",
+                birthdate = LocalDate.of(1867, 2, 9)
+            )
+
+            // When & Then
+            mockMvc.perform(
+                put("/api/authors/$invalidId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(updateRequest))
+            )
+                .andExpect(status().isBadRequest)
+        }
+
+        @Test
+        fun `更新時のバリデーションエラーが正常に動作すること`() {
+            // Given
+            val createRequest = AuthorCreateRequest(
+                name = "夏目漱石",
+                birthdate = LocalDate.of(1867, 2, 9)
+            )
+
+            val createResult = mockMvc.perform(
+                post("/api/authors")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createRequest))
+            )
+                .andExpect(status().isCreated)
+                .andReturn()
+
+            val createResponse = createResult.response.contentAsString
+            val createdAuthor = objectMapper.readTree(createResponse)
+            val authorId = createdAuthor.get("id").asText()
+
+            val invalidUpdateRequest = AuthorCreateRequest(
+                name = "",
+                birthdate = LocalDate.now().plusDays(1)
+            )
+
+            // When & Then
+            mockMvc.perform(
+                put("/api/authors/$authorId")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(invalidUpdateRequest))
+            )
+                .andExpect(status().isBadRequest)
+        }
+    }
+}

--- a/src/test/kotlin/io/github/t_suguru/book_management/controller/AuthorControllerTest.kt
+++ b/src/test/kotlin/io/github/t_suguru/book_management/controller/AuthorControllerTest.kt
@@ -125,28 +125,6 @@ class AuthorControllerTest : AbstractIntegrationTest() {
         }
 
         @Test
-        fun `複数のバリデーションエラーが同時に発生すること`() {
-            // Given
-            val request = AuthorCreateRequest(
-                name = "", // 空の名前 → NotBlankエラー
-                birthdate = LocalDate.now().plusDays(1) // 未来の日付 → Pastエラー
-            )
-
-            // When & Then
-            val result = mockMvc.perform(
-                post("/api/authors")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request))
-            )
-                .andExpect(status().isBadRequest)
-                .andReturn()
-
-            // デバッグ用: 実際のレスポンス内容を出力
-            println("Response Status: ${result.response.status}")
-            println("Response Body: ${result.response.contentAsString}")
-        }
-
-        @Test
         fun `不正な日付フォーマットでエラーが発生すること`() {
             // Given
             val invalidDateJson = """{"name": "夏目漱石", "birthdate": "invalid-date"}"""

--- a/src/test/kotlin/io/github/t_suguru/book_management/repository/AuthorRepositoryImplTest.kt
+++ b/src/test/kotlin/io/github/t_suguru/book_management/repository/AuthorRepositoryImplTest.kt
@@ -1,0 +1,99 @@
+package io.github.t_suguru.book_management.repository
+
+import io.github.t_suguru.book_management.AbstractIntegrationTest
+import io.github.t_suguru.book_management.domain.model.Author
+import io.github.t_suguru.book_management.infrastructure.repository.AuthorRepositoryImpl
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.util.*
+
+/**
+ * AuthorRepositoryImplの統合テスト
+ */
+@SpringBootTest
+@Transactional
+class AuthorRepositoryImplTest : AbstractIntegrationTest() {
+
+    @Autowired
+    private lateinit var authorRepository: AuthorRepositoryImpl
+
+    @Test
+    fun `著者を保存してIDが採番された状態で返ってこと`() {
+        // Given
+        val author = Author(
+            name = "夏目漱石",
+            birthdate = LocalDate.of(1867, 2, 9)
+        )
+
+        // When
+        val savedAuthor = authorRepository.save(author)
+
+        // Then
+        assertNotNull(savedAuthor.id)
+        assertEquals("夏目漱石", savedAuthor.name)
+        assertEquals(LocalDate.of(1867, 2, 9), savedAuthor.birthdate)
+        assertNotNull(savedAuthor.createdAt)
+        assertNotNull(savedAuthor.updatedAt)
+    }
+
+    @Test
+    fun `IDで著者を取得できること`() {
+        // Given
+        val author = Author(
+            name = "芥川龍之介",
+            birthdate = LocalDate.of(1892, 3, 1)
+        )
+        val savedAuthor = authorRepository.save(author)
+
+        // When
+        val foundAuthor = authorRepository.findById(savedAuthor.id!!)
+
+        // Then
+        assertNotNull(foundAuthor)
+        assertEquals(savedAuthor.id, foundAuthor?.id)
+        assertEquals("芥川龍之介", foundAuthor?.name)
+        assertEquals(LocalDate.of(1892, 3, 1), foundAuthor?.birthdate)
+    }
+
+    @Test
+    fun `存在しないIDで取得時にnullが返されること`() {
+        // Given
+        val nonExistentId = UUID.randomUUID()
+
+        // When
+        val foundAuthor = authorRepository.findById(nonExistentId)
+
+        // Then
+        assertNull(foundAuthor)
+    }
+
+    @Test
+    fun `著者情報を更新できること`() {
+        // Given
+        val author = Author(
+            name = "三島由紀夫",
+            birthdate = LocalDate.of(1925, 1, 14)
+        )
+        val savedAuthor = authorRepository.save(author)
+
+        // When
+        val updatedAuthor = savedAuthor.copy(
+            name = "三島由紀夫（更新後）",
+            birthdate = LocalDate.of(1925, 1, 14)
+        )
+        val result = authorRepository.update(updatedAuthor)
+
+        // Then
+        assertEquals("三島由紀夫（更新後）", result.name)
+        assertEquals(savedAuthor.id, result.id)
+        assertNotEquals(savedAuthor.updatedAt, result.updatedAt)
+
+        // データベースからも確認
+        val foundAuthor = authorRepository.findById(savedAuthor.id!!)
+        assertEquals("三島由紀夫（更新後）", foundAuthor?.name)
+    }
+}

--- a/src/test/kotlin/io/github/t_suguru/book_management/repository/DatabaseIntegrationTest.kt
+++ b/src/test/kotlin/io/github/t_suguru/book_management/repository/DatabaseIntegrationTest.kt
@@ -5,7 +5,6 @@ import io.github.t_suguru.book_management.db.tables.references.AUTHORS
 import io.github.t_suguru.book_management.db.tables.references.BOOKS
 import org.jooq.DSLContext
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -22,33 +21,32 @@ class DatabaseIntegrationTest : AbstractIntegrationTest() {
     private lateinit var dslContext: DSLContext
 
     @Test
-    @DisplayName("データベース接続が正常に動作することを確認")
-    fun testDatabaseConnection() {
-        // データベースへの簡単なクエリを実行してTestcontainersが正常に動作することを確認
+    fun `データベース接続が正常に動作することを確認`() {
+        // Given & When
         val tableCount = dslContext.selectCount()
             .from("information_schema.tables")
             .where("table_schema = 'public'")
             .fetchOne(0, Int::class.java) ?: 0
 
+        // Then
         // Flywayマイグレーションによってテーブルが作成されていることを確認
         assertTrue(tableCount > 0, "マイグレーションによってテーブルが作成されている必要があります")
     }
 
     @Test
-    @DisplayName("Flywayマイグレーションが正常に実行されることを確認")
-    fun testFlywayMigration() {
-        // flyway_schema_historyテーブルが存在することを確認
+    fun `Flywayマイグレーションが正常に実行されることを確認`() {
+        // Given & When
         val migrationHistoryCount = dslContext.selectCount()
             .from("flyway_schema_history")
             .fetchOne(0, Int::class.java) ?: 0
 
+        // Then
         assertTrue(migrationHistoryCount > 0, "Flywayマイグレーション履歴が存在する必要があります")
     }
 
     @Test
-    @DisplayName("jOOQの生成されたクラスが正常に動作することを確認")
-    fun testJooqGeneratedClasses() {
-        // jOOQの生成されたテーブルクラスを使用してtype-safeなクエリを実行
+    fun `jOOQの生成されたクラスが正常に動作することを確認`() {
+        // Given & When
         val authorCount = dslContext.selectCount()
             .from(AUTHORS)
             .fetchOne(0, Int::class.java)
@@ -57,6 +55,7 @@ class DatabaseIntegrationTest : AbstractIntegrationTest() {
             .from(BOOKS)
             .fetchOne(0, Int::class.java)
 
+        // Then
         // テーブルが存在し、クエリが正常に実行されることを確認
         // 初期状態では0件でも問題なし（テーブルが存在することが重要）
         authorCount?.let { assertTrue(it >= 0, "AUTHORSテーブルへのクエリが正常に実行される必要があります") }

--- a/src/test/kotlin/io/github/t_suguru/book_management/service/AuthorServiceTest.kt
+++ b/src/test/kotlin/io/github/t_suguru/book_management/service/AuthorServiceTest.kt
@@ -1,0 +1,112 @@
+package io.github.t_suguru.book_management.service
+
+import io.github.t_suguru.book_management.domain.model.Author
+import io.github.t_suguru.book_management.domain.repository.AuthorRepository
+import io.github.t_suguru.book_management.dto.AuthorCreateRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * AuthorServiceの単体テスト
+ */
+class AuthorServiceTest {
+
+    private lateinit var authorRepository: AuthorRepository
+    private lateinit var authorService: AuthorService
+
+    @BeforeEach
+    fun setUp() {
+        authorRepository = mockk()
+        authorService = AuthorService(authorRepository)
+    }
+
+    @Test
+    fun `著者作成時に正しくRepositoryが呼ばれること`() {
+        // Given
+        val request = AuthorCreateRequest(
+            name = "夏目漱石",
+            birthdate = LocalDate.of(1867, 2, 9)
+        )
+        
+        val expectedAuthor = Author(
+            id = UUID.randomUUID(),
+            name = "夏目漱石",
+            birthdate = LocalDate.of(1867, 2, 9),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+
+        every { authorRepository.save(any()) } returns expectedAuthor
+
+        // When
+        val result = authorService.createAuthor(request)
+
+        // Then
+        assertEquals(expectedAuthor, result)
+        verify(exactly = 1) { 
+            authorRepository.save(
+                match { it.name == "夏目漱石" && it.birthdate == LocalDate.of(1867, 2, 9) }
+            ) 
+        }
+    }
+
+    @Test
+    fun `存在する著者の更新が正常に動作すること`() {
+        // Given
+        val authorId = UUID.randomUUID()
+        val request = AuthorCreateRequest(
+            name = "夏目漱石（更新後）",
+            birthdate = LocalDate.of(1867, 2, 9)
+        )
+        
+        val existingAuthor = Author(
+            id = authorId,
+            name = "夏目漱石",
+            birthdate = LocalDate.of(1867, 2, 9)
+        )
+        
+        val updatedAuthor = existingAuthor.copy(
+            name = "夏目漱石（更新後）",
+            updatedAt = LocalDateTime.now()
+        )
+
+        every { authorRepository.findById(authorId) } returns existingAuthor
+        every { authorRepository.update(any()) } returns updatedAuthor
+
+        // When
+        val result = authorService.updateAuthor(authorId, request)
+
+        // Then
+        assertNotNull(result)
+        assertEquals("夏目漱石（更新後）", result?.name)
+        verify(exactly = 1) { authorRepository.findById(authorId) }
+        verify(exactly = 1) { authorRepository.update(any()) }
+    }
+
+    @Test
+    fun `存在しない著者の更新時にnullが返されること`() {
+        // Given
+        val authorId = UUID.randomUUID()
+        val request = AuthorCreateRequest(
+            name = "存在しない著者",
+            birthdate = LocalDate.of(1867, 2, 9)
+        )
+
+        every { authorRepository.findById(authorId) } returns null
+
+        // When
+        val result = authorService.updateAuthor(authorId, request)
+
+        // Then
+        assertNull(result)
+        verify(exactly = 1) { authorRepository.findById(authorId) }
+        verify(exactly = 0) { authorRepository.update(any()) }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Book Management System built using Spring Boot, Kotlin, and jOOQ. It includes comprehensive functionality for managing authors, such as creating, updating, and retrieving author details. The changes span across the core application, repository, service, and controller layers, as well as integration and unit tests. Below is a breakdown of the most important changes:

### Core Application Setup and Documentation
* Added a detailed `README.md` file describing the project setup, including prerequisites (JDK 21, Docker), database configuration, build instructions, and the project's directory structure. It also lists key Gradle tasks for building, testing, and running the application.

### Author Management Features
* Introduced the `AuthorController` to handle API endpoints for creating and updating authors. It uses Spring Boot annotations and integrates with the `AuthorService`.
* Created the `Author` domain model to represent author entities with fields like `id`, `name`, `birthdate`, and timestamps.
* Added the `AuthorRepository` interface and its implementation (`AuthorRepositoryImpl`) for database operations, leveraging jOOQ for type-safe queries. [[1]](diffhunk://#diff-0a2cdbbe02ad814428cad7d9322302218b3471c1c6ee6329056075827d0751c8R1-R13) [[2]](diffhunk://#diff-ddd76293026bd29f47b24f867e120c9e87b498dce3b74ddcc499920d83118c3fR1-R65)
* Developed the `AuthorService` to encapsulate business logic for author creation, updates, and retrieval by ID.
* Introduced the `AuthorCreateRequest` DTO with validation annotations for input data.

### Testing
* Added integration tests for `AuthorController` to validate API endpoints, including success cases and validation error scenarios.
* Implemented integration tests for `AuthorRepositoryImpl` to verify database operations like saving, updating, and retrieving authors.
* Updated `DatabaseIntegrationTest` to use descriptive test method names and removed the `@DisplayName` annotation for improved readability. [[1]](diffhunk://#diff-d6b856e92740fecf62f8f87adc6a0e72790bce70b9f1168cf37eb86758c4ebd3L8) [[2]](diffhunk://#diff-d6b856e92740fecf62f8f87adc6a0e72790bce70b9f1168cf37eb86758c4ebd3L25-R49)