### PR TITLE
著者に紐づく書籍の取得機能の追加 書籍のドメインモデルに著者のリストを追加

### DIFF
--- a/src/main/kotlin/io/github/t_suguru/book_management/domain/model/Book.kt
+++ b/src/main/kotlin/io/github/t_suguru/book_management/domain/model/Book.kt
@@ -11,15 +11,19 @@ data class Book(
     val title: String,
     val price: Int,
     val status: PublicationStatus,
-    val authorIds: List<UUID>,
+    val authors: List<Author>,
     val createdAt: LocalDateTime? = null,
     val updatedAt: LocalDateTime? = null
 ) {
     init {
         require(price >= 0) { "価格は0以上である必要があります" }
-        require(authorIds.isNotEmpty()) { "最低1人の著者が必要です" }
+        require(authors.isNotEmpty()) { "最低1人の著者が必要です" }
     }
     
-    // 著者IDをソート済みの状態で保持するためのコピー関数
-    fun withSortedAuthorIds(): Book = this.copy(authorIds = authorIds.sorted())
+    // 便利メソッド：著者IDのリストを取得
+    val authorIds: List<UUID>
+        get() = authors.mapNotNull { it.id }
+    
+    // 著者を名前でソートしたコピーを作成
+    fun withSortedAuthors(): Book = this.copy(authors = authors.sortedBy { it.name })
 }

--- a/src/main/kotlin/io/github/t_suguru/book_management/domain/repository/BookRepository.kt
+++ b/src/main/kotlin/io/github/t_suguru/book_management/domain/repository/BookRepository.kt
@@ -10,4 +10,5 @@ interface BookRepository {
     fun save(book: Book): Book
     fun findById(id: UUID): Book?
     fun update(book: Book): Book
+    fun findByAuthorId(authorId: UUID): List<Book>
 }

--- a/src/main/kotlin/io/github/t_suguru/book_management/service/AuthorBookService.kt
+++ b/src/main/kotlin/io/github/t_suguru/book_management/service/AuthorBookService.kt
@@ -1,0 +1,30 @@
+package io.github.t_suguru.book_management.service
+
+import io.github.t_suguru.book_management.domain.model.Book
+import io.github.t_suguru.book_management.domain.repository.AuthorRepository
+import io.github.t_suguru.book_management.domain.repository.BookRepository
+import org.springframework.stereotype.Service
+import java.util.*
+
+/**
+ * 著者と書籍の統合サービス
+ * AuthorとBookの境界を跨ぐ操作を担当
+ */
+@Service
+class AuthorBookService(
+    private val authorRepository: AuthorRepository,
+    private val bookRepository: BookRepository
+) {
+    
+    /**
+     * 著者の書籍一覧を取得する
+     * 著者の存在チェックも行う
+     */
+    fun getBooksByAuthorId(authorId: UUID): List<Book> {
+        // 著者の存在確認
+        val author = authorRepository.findById(authorId) ?: return emptyList()
+        
+        // 書籍一覧を取得
+        return bookRepository.findByAuthorId(authorId)
+    }
+}

--- a/src/main/kotlin/io/github/t_suguru/book_management/service/BookService.kt
+++ b/src/main/kotlin/io/github/t_suguru/book_management/service/BookService.kt
@@ -2,6 +2,7 @@ package io.github.t_suguru.book_management.service
 
 import io.github.t_suguru.book_management.domain.model.Book
 import io.github.t_suguru.book_management.domain.model.PublicationStatus
+import io.github.t_suguru.book_management.domain.repository.AuthorRepository
 import io.github.t_suguru.book_management.domain.repository.BookRepository
 import io.github.t_suguru.book_management.dto.BookCreateRequest
 import io.github.t_suguru.book_management.dto.BookUpdateRequest
@@ -14,19 +15,25 @@ import java.util.*
  */
 @Service
 class BookService(
-    private val bookRepository: BookRepository
+    private val bookRepository: BookRepository,
+    private val authorRepository: AuthorRepository,
 ) {
-
     /**
      * 書籍を作成する
      */
     @Transactional
     fun createBook(request: BookCreateRequest): Book {
+        // 著者の存在チェックと取得
+        val authors = request.authorIds.map { authorId ->
+            authorRepository.findById(authorId)
+                ?: throw IllegalArgumentException("著者が見つかりません: $authorId")
+        }
+
         val book = Book(
             title = request.title,
             price = request.price,
             status = request.status,
-            authorIds = request.authorIds
+            authors = authors
         )
         return bookRepository.save(book)
     }
@@ -37,21 +44,28 @@ class BookService(
     @Transactional
     fun updateBook(id: UUID, request: BookUpdateRequest): Book? {
         val existingBook = bookRepository.findById(id) ?: return null
-        
+
         // 出版済み→未出版への変更は許可しない
         // ルールが増えるようならばドメイン層に移す
-        if (existingBook.status == PublicationStatus.PUBLISHED && 
-            request.status == PublicationStatus.UNPUBLISHED) {
+        if (existingBook.status == PublicationStatus.PUBLISHED &&
+            request.status == PublicationStatus.UNPUBLISHED
+        ) {
             throw IllegalArgumentException("出版済みの書籍を未出版に変更することはできません")
         }
-        
+
+        // 著者の存在チェックと取得
+        val authors = request.authorIds.map { authorId ->
+            authorRepository.findById(authorId)
+                ?: throw IllegalArgumentException("著者が見つかりません: $authorId")
+        }
+
         val updatedBook = existingBook.copy(
             title = request.title,
             price = request.price,
             status = request.status,
-            authorIds = request.authorIds
+            authors = authors
         )
-        
+
         return bookRepository.update(updatedBook)
     }
 }

--- a/src/test/kotlin/io/github/t_suguru/book_management/controller/AuthorControllerTest.kt
+++ b/src/test/kotlin/io/github/t_suguru/book_management/controller/AuthorControllerTest.kt
@@ -10,8 +10,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.util.*

--- a/src/test/kotlin/io/github/t_suguru/book_management/controller/BookControllerTest.kt
+++ b/src/test/kotlin/io/github/t_suguru/book_management/controller/BookControllerTest.kt
@@ -203,7 +203,7 @@ class BookControllerTest : AbstractIntegrationTest() {
                     title = "羅生門",
                     price = 800,
                     status = PublicationStatus.UNPUBLISHED,
-                    authorIds = listOf(author.id!!)
+                    authors = listOf(author)
                 )
             )
 
@@ -242,7 +242,7 @@ class BookControllerTest : AbstractIntegrationTest() {
                     title = "人間失格",
                     price = 1200,
                     status = PublicationStatus.PUBLISHED,
-                    authorIds = listOf(author.id!!)
+                    authors = listOf(author)
                 )
             )
 

--- a/src/test/kotlin/io/github/t_suguru/book_management/service/AuthorBookServiceTest.kt
+++ b/src/test/kotlin/io/github/t_suguru/book_management/service/AuthorBookServiceTest.kt
@@ -1,0 +1,120 @@
+package io.github.t_suguru.book_management.service
+
+import io.github.t_suguru.book_management.domain.model.Author
+import io.github.t_suguru.book_management.domain.model.Book
+import io.github.t_suguru.book_management.domain.model.PublicationStatus
+import io.github.t_suguru.book_management.domain.repository.AuthorRepository
+import io.github.t_suguru.book_management.domain.repository.BookRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+/**
+ * AuthorBookServiceの単体テスト
+ */
+class AuthorBookServiceTest {
+
+    private lateinit var authorRepository: AuthorRepository
+    private lateinit var bookRepository: BookRepository
+    private lateinit var authorBookService: AuthorBookService
+
+    @BeforeEach
+    fun setUp() {
+        authorRepository = mockk()
+        bookRepository = mockk()
+        authorBookService = AuthorBookService(authorRepository, bookRepository)
+    }
+
+    @Test
+    fun `著者が存在する場合に書籍一覧を取得できること`() {
+        // Given
+        val authorId = UUID.randomUUID()
+
+        val author = Author(
+            id = authorId,
+            name = "夏目漱石",
+            birthdate = LocalDate.of(1867, 2, 9),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+
+        val expectedBooks = listOf(
+            Book(
+                id = UUID.randomUUID(),
+                title = "吾輩は猫である",
+                price = 1500,
+                status = PublicationStatus.PUBLISHED,
+                authors = listOf(author),
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now()
+            ),
+            Book(
+                id = UUID.randomUUID(),
+                title = "坊っちゃん",
+                price = 1200,
+                status = PublicationStatus.PUBLISHED,
+                authors = listOf(author),
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now()
+            )
+        )
+
+        every { authorRepository.findById(authorId) } returns author
+        every { bookRepository.findByAuthorId(authorId) } returns expectedBooks
+
+        // When
+        val result = authorBookService.getBooksByAuthorId(authorId)
+
+        // Then
+        assertEquals(expectedBooks, result)
+        verify(exactly = 1) { authorRepository.findById(authorId) }
+        verify(exactly = 1) { bookRepository.findByAuthorId(authorId) }
+    }
+
+    @Test
+    fun `著者が存在しない場合に空のリストが返ること`() {
+        // Given
+        val nonExistentAuthorId = UUID.randomUUID()
+
+        every { authorRepository.findById(nonExistentAuthorId) } returns null
+
+        // When
+        val result = authorBookService.getBooksByAuthorId(nonExistentAuthorId)
+
+        // Then
+        assertTrue(result.isEmpty())
+        verify(exactly = 1) { authorRepository.findById(nonExistentAuthorId) }
+        verify(exactly = 0) { bookRepository.findByAuthorId(any()) }
+    }
+
+    @Test
+    fun `著者は存在するが書籍がない場合に空のリストが返ること`() {
+        // Given
+        val authorId = UUID.randomUUID()
+
+        val author = Author(
+            id = authorId,
+            name = "新人作家",
+            birthdate = LocalDate.of(1990, 1, 1),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+
+        every { authorRepository.findById(authorId) } returns author
+        every { bookRepository.findByAuthorId(authorId) } returns emptyList()
+
+        // When
+        val result = authorBookService.getBooksByAuthorId(authorId)
+
+        // Then
+        assertTrue(result.isEmpty())
+        verify(exactly = 1) { authorRepository.findById(authorId) }
+        verify(exactly = 1) { bookRepository.findByAuthorId(authorId) }
+    }
+}

--- a/src/test/kotlin/io/github/t_suguru/book_management/service/AuthorServiceTest.kt
+++ b/src/test/kotlin/io/github/t_suguru/book_management/service/AuthorServiceTest.kt
@@ -34,7 +34,7 @@ class AuthorServiceTest {
             name = "夏目漱石",
             birthdate = LocalDate.of(1867, 2, 9)
         )
-        
+
         val expectedAuthor = Author(
             id = UUID.randomUUID(),
             name = "夏目漱石",
@@ -50,10 +50,10 @@ class AuthorServiceTest {
 
         // Then
         assertEquals(expectedAuthor, result)
-        verify(exactly = 1) { 
+        verify(exactly = 1) {
             authorRepository.save(
                 match { it.name == "夏目漱石" && it.birthdate == LocalDate.of(1867, 2, 9) }
-            ) 
+            )
         }
     }
 
@@ -65,13 +65,13 @@ class AuthorServiceTest {
             name = "夏目漱石（更新後）",
             birthdate = LocalDate.of(1867, 2, 9)
         )
-        
+
         val existingAuthor = Author(
             id = authorId,
             name = "夏目漱石",
             birthdate = LocalDate.of(1867, 2, 9)
         )
-        
+
         val updatedAuthor = existingAuthor.copy(
             name = "夏目漱石（更新後）",
             updatedAt = LocalDateTime.now()

--- a/src/test/kotlin/io/github/t_suguru/book_management/service/BookServiceTest.kt
+++ b/src/test/kotlin/io/github/t_suguru/book_management/service/BookServiceTest.kt
@@ -1,7 +1,9 @@
 package io.github.t_suguru.book_management.service
 
+import io.github.t_suguru.book_management.domain.model.Author
 import io.github.t_suguru.book_management.domain.model.Book
 import io.github.t_suguru.book_management.domain.model.PublicationStatus
+import io.github.t_suguru.book_management.domain.repository.AuthorRepository
 import io.github.t_suguru.book_management.domain.repository.BookRepository
 import io.github.t_suguru.book_management.dto.BookCreateRequest
 import io.github.t_suguru.book_management.dto.BookUpdateRequest
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -19,37 +22,47 @@ import java.util.*
  * BookServiceの単体テスト
  */
 class BookServiceTest {
-
     private lateinit var bookRepository: BookRepository
+    private lateinit var authorRepository: AuthorRepository
     private lateinit var bookService: BookService
 
     @BeforeEach
     fun setUp() {
         bookRepository = mockk()
-        bookService = BookService(bookRepository)
+        authorRepository = mockk()
+        bookService = BookService(bookRepository, authorRepository)
     }
 
     @Test
     fun `書籍作成時に正しくRepositoryが呼ばれること`() {
         // Given
         val authorId = UUID.randomUUID()
+        val author = Author(
+            id = authorId,
+            name = "夏目漱石",
+            birthdate = LocalDate.of(1867, 2, 9),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+
         val request = BookCreateRequest(
             title = "吾輩は猫である",
             price = 1500,
             status = PublicationStatus.UNPUBLISHED,
             authorIds = listOf(authorId)
         )
-        
+
         val expectedBook = Book(
             id = UUID.randomUUID(),
             title = "吾輩は猫である",
             price = 1500,
             status = PublicationStatus.UNPUBLISHED,
-            authorIds = listOf(authorId),
+            authors = listOf(author),
             createdAt = LocalDateTime.now(),
             updatedAt = LocalDateTime.now()
         )
 
+        every { authorRepository.findById(authorId) } returns author
         every { bookRepository.save(any()) } returns expectedBook
 
         // When
@@ -57,6 +70,7 @@ class BookServiceTest {
 
         // Then
         assertEquals(expectedBook, result)
+        verify(exactly = 1) { authorRepository.findById(authorId) }
         verify(exactly = 1) { bookRepository.save(any()) }
     }
 
@@ -65,13 +79,20 @@ class BookServiceTest {
         // Given
         val bookId = UUID.randomUUID()
         val authorId = UUID.randomUUID()
-        
+        val existingAuthor = Author(
+            id = UUID.randomUUID(),
+            name = "夏目漱石",
+            birthdate = LocalDate.of(1867, 2, 9),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+
         val existingBook = Book(
             id = bookId,
             title = "旧タイトル",
             price = 1000,
             status = PublicationStatus.UNPUBLISHED,
-            authorIds = listOf(authorId),
+            authors = listOf(existingAuthor),
             createdAt = LocalDateTime.now(),
             updatedAt = LocalDateTime.now()
         )
@@ -90,7 +111,8 @@ class BookServiceTest {
             updatedAt = LocalDateTime.now()
         )
 
-        every { bookRepository.findById(bookId) } returns existingBook
+        every { authorRepository.findById(authorId) } returns existingAuthor
+        every { bookRepository.findById(bookId) } returns expectedBook
         every { bookRepository.update(any()) } returns expectedBook
 
         // When
@@ -107,7 +129,7 @@ class BookServiceTest {
         // Given
         val bookId = UUID.randomUUID()
         val authorId = UUID.randomUUID()
-        
+
         val request = BookUpdateRequest(
             title = "新タイトル",
             price = 2000,
@@ -131,13 +153,19 @@ class BookServiceTest {
         // Given
         val bookId = UUID.randomUUID()
         val authorId = UUID.randomUUID()
-        
+        val existingAuthor = Author(
+            id = UUID.randomUUID(),
+            name = "夏目漱石",
+            birthdate = LocalDate.of(1867, 2, 9),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
         val existingBook = Book(
             id = bookId,
             title = "出版済み書籍",
             price = 1000,
             status = PublicationStatus.PUBLISHED,
-            authorIds = listOf(authorId),
+            authors = listOf(existingAuthor),
             createdAt = LocalDateTime.now(),
             updatedAt = LocalDateTime.now()
         )
@@ -156,7 +184,7 @@ class BookServiceTest {
             bookService.updateBook(bookId, request)
         }
         assertEquals("出版済みの書籍を未出版に変更することはできません", exception.message)
-        
+
         verify(exactly = 1) { bookRepository.findById(bookId) }
         verify(exactly = 0) { bookRepository.update(any()) }
     }


### PR DESCRIPTION
This pull request introduces significant changes to the `Book` domain model, repository, and service layers to enhance the handling of authors as full-fledged objects rather than just IDs. Additionally, it adds new functionality for querying books by author and updates tests to reflect these changes.

### Domain Model Changes:
* [`src/main/kotlin/io/github/t_suguru/book_management/domain/model/Book.kt`](diffhunk://#diff-d227f132127c3e77c0ab359d17e47a9282afa5bce14e5ce059d3a56fa5465a47L14-R28): Replaced `authorIds` with `authors` (a list of `Author` objects) in the `Book` class, added a computed property `authorIds` for backward compatibility, and introduced a method to sort authors by name.

### Repository Enhancements:
* [`src/main/kotlin/io/github/t_suguru/book_management/domain/repository/BookRepository.kt`](diffhunk://#diff-a866c0b996c9ab10e3e9a72fb5b5bf61de4c987c1bb63806616d2ac3297b5ed6R13): Added a new method `findByAuthorId` to retrieve books associated with a specific author.
* [`src/main/kotlin/io/github/t_suguru/book_management/infrastructure/repository/BookRepositoryImpl.kt`](diffhunk://#diff-4ba3d2aa70836b7467948838b8b42c03595188cdb346274f176c0b2171fbe9e1L44-R89): Updated `findById` to fetch associated authors using `multiset` for a single query, implemented `findByAuthorId` to retrieve books and their authors efficiently, and removed redundant sorting of `authorIds`. [[1]](diffhunk://#diff-4ba3d2aa70836b7467948838b8b42c03595188cdb346274f176c0b2171fbe9e1L44-R89) [[2]](diffhunk://#diff-4ba3d2aa70836b7467948838b8b42c03595188cdb346274f176c0b2171fbe9e1L100-R162)

### Service Layer Updates:
* [`src/main/kotlin/io/github/t_suguru/book_management/service/AuthorBookService.kt`](diffhunk://#diff-7426a137e6bf30b77070d136d38fc6811ca230b11ba321711264f1e95d1c71d9R1-R30): Introduced a new service to handle cross-boundary operations between authors and books, including fetching books by author with existence checks.
* [`src/main/kotlin/io/github/t_suguru/book_management/service/BookService.kt`](diffhunk://#diff-7e05d5be71356cff9e22874f9b2a7d41d43d9d769c94a7d390986de6bd11863eL17-R36): Updated `createBook` and `updateBook` methods to validate author existence and retrieve full `Author` objects for the `Book` model. [[1]](diffhunk://#diff-7e05d5be71356cff9e22874f9b2a7d41d43d9d769c94a7d390986de6bd11863eL17-R36) [[2]](diffhunk://#diff-7e05d5be71356cff9e22874f9b2a7d41d43d9d769c94a7d390986de6bd11863eL44-R66)

### Test Updates:
* [`src/test/kotlin/io/github/t_suguru/book_management/repository/BookRepositoryImplTest.kt`](diffhunk://#diff-eb51a5a01d988914b22c6a298352eb86b4b9dff709a970885144bff3592a75a0L39-R43): Updated tests to verify the new `authors` property instead of `authorIds`, added tests for `findByAuthorId`, and ensured proper validation for non-existent authors. [[1]](diffhunk://#diff-eb51a5a01d988914b22c6a298352eb86b4b9dff709a970885144bff3592a75a0L39-R43) [[2]](diffhunk://#diff-eb51a5a01d988914b22c6a298352eb86b4b9dff709a970885144bff3592a75a0R203-R278)
* [`src/test/kotlin/io/github/t_suguru/book_management/controller/BookControllerTest.kt`](diffhunk://#diff-6a860801c52802677cf5496d538bd0f8755ed3ee197d2beb5e8c04917960f807L206-R206): Updated test cases to reflect the replacement of `authorIds` with `authors`. [[1]](diffhunk://#diff-6a860801c52802677cf5496d538bd0f8755ed3ee197d2beb5e8c04917960f807L206-R206) [[2]](diffhunk://#diff-6a860801c52802677cf5496d538bd0f8755ed3ee197d2beb5e8c04917960f807L245-R245)

These changes improve the flexibility and expressiveness of the `Book` model, enhance repository efficiency, and ensure robust validation in the service layer.