### PR TITLE
readmeに記載の手順修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ AUTHOR_RESPONSE=$(curl -s -X POST http://localhost:8080/api/authors \
     "birthdate": "1867-02-09"
   }')
 
-# 著者IDを抽出（jqなし - sedを使用）
-AUTHOR_ID=$(echo $AUTHOR_RESPONSE | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+# 著者IDを抽出（JSONの先頭のidフィールドを取得）
+AUTHOR_ID=$(echo $AUTHOR_RESPONSE | sed 's/^{"id":"\([^"]*\)".*/\1/')
 
 # 2. 書籍を作成
 BOOK_RESPONSE=$(curl -s -X POST http://localhost:8080/api/books \
@@ -242,8 +242,8 @@ BOOK_RESPONSE=$(curl -s -X POST http://localhost:8080/api/books \
     \"authorIds\": [\"$AUTHOR_ID\"]
   }")
 
-# 書籍IDを抽出（jqなし - sedを使用）
-BOOK_ID=$(echo $BOOK_RESPONSE | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+# 書籍IDを抽出（JSONの先頭のidフィールドを取得）
+BOOK_ID=$(echo $BOOK_RESPONSE | sed 's/^{"id":"\([^"]*\)".*/\1/')
 
 # 3. 著者の書籍一覧を取得
 curl -X GET http://localhost:8080/api/authors/$AUTHOR_ID/books


### PR DESCRIPTION
This pull request updates the `README.md` file to simplify the extraction of IDs from JSON responses by modifying the `sed` commands used in the examples.

### Updates to ID extraction examples:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L232-R233): Changed the `sed` command for extracting `AUTHOR_ID` to retrieve the `id` field from the beginning of the JSON response, simplifying the pattern.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L245-R246): Updated the `sed` command for extracting `BOOK_ID` to similarly retrieve the `id` field from the beginning of the JSON response, aligning with the new approach.